### PR TITLE
devices.xml: Added Sony Xperia U (kumquat)

### DIFF
--- a/res/raw/devices.xml
+++ b/res/raw/devices.xml
@@ -110,4 +110,11 @@ File contain partitions layout for flashing kernel & recovery
         <recovery>/dev/block/platform/sdhci-tegra.3/by-name/SOS</recovery>
         <cache>/dev/block/platform/sdhci-tegra.3/by-name/CAC</cache>
     </device>
+    <device>
+        <model>ST25,ST25i,ST25a, Xperia U, kumquat</model> <!-- Sony Xperia U kumquat -->
+        <kernel>/dev/block/mmcblk0p9</kernel>
+        <recovery>/dev/block/mmcblk0p9</recovery>
+        <cache>/dev/block/mmcblk0p12</cache>
+    </device>
+
 </devices>


### PR DESCRIPTION
Added Xperia U

model: ST25, ST25i, ST25a, Xperia U, kumquat
kernel partition: /dev/block/mmcblk0p9
recovery partion: /dev/block/mmcblk0p9 (we don't have independent recovery partition, so it's the same as kernel
cache partition: /dev/block/mmcblk0p12

system partition: /dev/block/mmcblk0p10
data partition: /dev/block/mmcblk0p11
modemfs partition: /dev/block/mmcblk0p6
